### PR TITLE
Update video-cli-commands.md

### DIFF
--- a/doc_source/video-cli-commands.md
+++ b/doc_source/video-cli-commands.md
@@ -34,7 +34,6 @@ To run this procedure, you need to have the AWS CLI installed\. For more informa
 
    ```
    aws rekognition start-label-detection --video "S3Object={Bucket="bucketname",Name="videofile"}" \
-   --endpoint-url Endpoint \
    --notification-channel "SNSTopicArn=TopicARN,RoleArn=RoleARN" \
    --region us-east-1 \
    --profile RekognitionUser
@@ -42,9 +41,9 @@ To run this procedure, you need to have the AWS CLI installed\. For more informa
 
    Update the following values:
    + Change `bucketname` and `videofile` to the Amazon S3 bucket name and file name that you specified in step 6\.
-   + Change `Endpoint` and `us-east-1` to the AWS endpoint and region that you're using\.
    + Change `TopicARN` to the ARN of the Amazon SNS topic you created in step 2 of the previous procedure\.
    + Change `RoleARN` to the ARN of the IAM role you created in step 1 of the previous procedure\.
+   + Change `us-east-1` to the AWS region that you're using.
    + Change `RekognitionUser` to an AWS account that has permissions to call Amazon Rekognition Video operations\.
 
 1. Note the value of `JobId` in the response\. The response looks similar to the following JSON example\.
@@ -63,14 +62,13 @@ To run this procedure, you need to have the AWS CLI installed\. For more informa
 
    ```
    aws rekognition get-label-detection  --job-id JobId \
-   --endpoint-url Endpoint \
    --region us-east-1 \
    --profile RekognitionUser
    ```
 
    Update the following values:
    + Change `JobId` to match the job identifier that you noted in step 2\.
-   + Change `Endpoint` and `us-east-1` to the AWS endpoint and region that you're using\.
+   + Change `us-east-1` to the AWS region that you're using\.
    + Change `RekognitionUser` to an AWS account that has permissions to call Amazon Rekognition Video operations\.
 
    The results look similar to the following example JSON:


### PR DESCRIPTION
The --endpoint-url flags are not required and specific to the cli. It does not have a relation to Rekognition directly and users are easily confused by this flag. For general use, the enpoint-url flag is not required to be set where using the CLI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
