### PR TITLE
python_examples: do not import os.environ when not needed

### DIFF
--- a/code_examples/python_examples/image/python-describe-collection.py
+++ b/code_examples/python_examples/image/python-describe-collection.py
@@ -3,7 +3,6 @@
 
 import boto3
 from botocore.exceptions import ClientError
-from os import environ
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
os.environ is not used and not needed in this code example. Removed this import.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
