### PR TITLE
python_examples: Remove unneeded function assignment

### DIFF
--- a/code_examples/python_examples/image/python-add-faces-to-collection.py
+++ b/code_examples/python_examples/image/python-add-faces-to-collection.py
@@ -11,8 +11,6 @@ if __name__ == "__main__":
     
     client=boto3.client('rekognition')
 
-    response=client.index_faces
-
     response=client.index_faces(CollectionId=collectionId,
                                 Image={'S3Object':{'Bucket':bucket,'Name':photo}},
                                 ExternalImageId=photo,


### PR DESCRIPTION
Remove a duplicated use of function index_faces().

Tested on Python 3.5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
