### PR TITLE
fix .net example failure

### DIFF
--- a/doc_source/faces-comparefaces.md
+++ b/doc_source/faces-comparefaces.md
@@ -243,7 +243,7 @@ CompareFaces uses machine learning algorithms, which are probabilistic\. A false
    
    public class CompareFaces
    {
-       public static void Example()
+       public static async Task Example()
        {
            float similarityThreshold = 70F;
            String sourceImage = "source.jpg";
@@ -292,7 +292,7 @@ CompareFaces uses machine learning algorithms, which are probabilistic\. A false
            };
    
            // Call operation
-           CompareFacesResponse compareFacesResponse = rekognitionClient.CompareFaces(compareFacesRequest);
+           CompareFacesResponse compareFacesResponse = await rekognitionClient.CompareFacesAsync(compareFacesRequest);
    
            // Display results
            foreach(CompareFacesMatch match in compareFacesResponse.FaceMatches)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`CompareFaces` is not a public method, use `CompareFacesAsync`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
